### PR TITLE
Linearity

### DIFF
--- a/bayem/__init__.py
+++ b/bayem/__init__.py
@@ -1,5 +1,6 @@
 from .distributions import Gamma, MVN
 from .json_io import save_json, load_json
 from .vba import vba, VBA, VBOptions
+from .checks import linearity_analysis
 
 __version__ = "2021.0.0"

--- a/bayem/__init__.py
+++ b/bayem/__init__.py
@@ -1,6 +1,6 @@
-from .distributions import Gamma, MVN
-from .json_io import save_json, load_json
-from .vba import vba, VBA, VBOptions
 from .checks import linearity_analysis
+from .distributions import MVN, Gamma
+from .json_io import load_json, save_json
+from .vba import VBA, VBOptions, vba
 
 __version__ = "2021.0.0"

--- a/bayem/checks.py
+++ b/bayem/checks.py
@@ -24,12 +24,12 @@ def _measure(true, lin, norm):
 def linearity_analysis(
     model,
     posterior,
-    n_sd=3,
+    sd_range=range(-3, 4),
     norm=np.linalg.norm,
     show=False,
 ):
     """
-    Compares the `model` responses `n_sd` standard deviations around the
+    Compares the `model` responses `sd_range` standard deviations around the
     `posterior` mean with its linearization to estimate a measure of
     linearity.
     """
@@ -45,13 +45,8 @@ def linearity_analysis(
         single_sd = np.zeros_like(posterior.mean)
         single_sd[i_sd] = sd
 
-        sd_range = range(-n_sd, n_sd + 1)
         prms = [posterior.mean + i * single_sd for i in sd_range]
-        tick_labels = (
-            [f"µ{i}σ" for i in range(-n_sd, 0)]
-            + ["µ"]
-            + [f"µ+{i}σ" for i in range(1, n_sd + 1)]
-        )
+        tick_labels = [f"µ{i:+4.2f}σ" for i in sd_range]
 
         for noise_group in k.keys():
 

--- a/bayem/checks.py
+++ b/bayem/checks.py
@@ -1,0 +1,72 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import pearsonr
+from .vba import DictModelError
+
+
+def _measure(true, lin, norm):
+    a, b = np.asarray(true), np.asarray(lin)
+    error = norm(a - b)
+    ref = norm(b)
+    return error / ref
+
+
+def linearity_analysis(
+    model,
+    posterior,
+    n_sd=3,
+    noise_group=0,
+    norm=np.linalg.norm,
+    show=False,
+):
+    """
+    Compares the `model` responses `n_sd` standard deviations around the
+    `posterior` mean with its linearization to estimate a measure of
+    linearity.
+
+    Note that it does not evaluate the full `model` but only a single
+    `noise_group`.
+    """
+
+    model = DictModelError(model, jac=None, noise0=None)
+
+    k, J = model.first_call(posterior.mean)
+    k_MAP = k[noise_group]
+    J_MAP = J[noise_group]
+
+    linearity_measure = {}
+
+    for i_sd, sd in enumerate(posterior.std_diag):
+        name = posterior.parameter_names[i_sd]
+        single_sd = np.zeros_like(posterior.mean)
+        single_sd[i_sd] = sd
+
+        sd_range = range(-n_sd, n_sd + 1)
+        prms = [posterior.mean + i * single_sd for i in sd_range]
+        tick_labels = (
+            [f"µ{i}σ" for i in range(-n_sd, 0)]
+            + ["µ"]
+            + [f"µ+{i}σ" for i in range(1, n_sd + 1)]
+        )
+
+        me_real = [model._Tk(model.f(prm))[noise_group] for prm in prms]
+
+        me_lin = [k_MAP + J_MAP @ (prm - posterior.mean) for prm in prms]
+
+        if show:
+            p = plt.plot(sd_range, [norm(model) for model in me_real], label=f"{name}")
+            plt.plot(
+                sd_range,
+                [norm(model) for model in me_lin],
+                ls=":",
+                color=p[0].get_color(),
+            )
+
+        linearity_measure[name] = _measure(me_real, me_lin, norm=norm)
+
+    if show:
+        plt.xticks(sd_range, tick_labels)
+        plt.legend()
+        plt.show()
+
+    return linearity_measure

--- a/bayem/checks.py
+++ b/bayem/checks.py
@@ -48,13 +48,15 @@ def linearity_analysis(
         prms = [posterior.mean + i * single_sd for i in sd_range]
         tick_labels = [f"µ{i:+4.2f}σ" for i in sd_range]
 
-        for noise_group in k.keys():
+        all_me_real = [model._Tk(model.f(prm)) for prm in prms]
 
-            me_real = [model._Tk(model.f(prm))[noise_group] for prm in prms]
+        for noise_group in k.keys():
 
             me_lin = [
                 k[noise_group] + J[noise_group] @ (prm - posterior.mean) for prm in prms
             ]
+
+            me_real = [me[noise_group] for me in all_me_real]
 
             if show:
                 p = plt.plot(

--- a/bayem/checks.py
+++ b/bayem/checks.py
@@ -1,7 +1,8 @@
-import numpy as np
-import matplotlib.pyplot as plt
-from scipy.stats import pearsonr
 from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+
 from .vba import DictModelError
 
 
@@ -30,7 +31,7 @@ def linearity_analysis(
     k, J = model.first_call(posterior.mean)
 
     linearity_measure = defaultdict(dict)
-        
+
     for i_sd, sd in enumerate(posterior.std_diag):
         name = posterior.parameter_names[i_sd]
         single_sd = np.zeros_like(posterior.mean)
@@ -48,10 +49,16 @@ def linearity_analysis(
 
             me_real = [model._Tk(model.f(prm))[noise_group] for prm in prms]
 
-            me_lin = [k[noise_group]+ J[noise_group] @ (prm - posterior.mean) for prm in prms]
+            me_lin = [
+                k[noise_group] + J[noise_group] @ (prm - posterior.mean) for prm in prms
+            ]
 
             if show:
-                p = plt.plot(sd_range, [norm(model) for model in me_real], label=f"{name}, noise group {noise_group}")
+                p = plt.plot(
+                    sd_range,
+                    [norm(model) for model in me_real],
+                    label=f"{name}, noise group {noise_group}",
+                )
                 plt.plot(
                     sd_range,
                     [norm(model) for model in me_lin],

--- a/bayem/checks.py
+++ b/bayem/checks.py
@@ -7,9 +7,17 @@ from .vba import DictModelError
 
 
 def _measure(true, lin, norm):
-    a, b = np.asarray(true), np.asarray(lin)
-    error = norm(a - b)
-    ref = norm(b)
+    y_true, y_lin = np.asarray(true), np.asarray(lin)
+    error = norm(y_true - y_lin)
+    ref = norm(y_lin)
+    if ref == 0:
+        # Extremely unlikely case:
+        # 1) model must not depend on parameters
+        # 2) model must (depending on the norm used...) always be zero.
+        #    IMO impossible, if there is any noise in the data.
+        # Thus, we explicitly avoid the division and return nan and the user
+        # should recognize an issue and investigate that case manually.
+        return np.nan
     return error / ref
 
 

--- a/bayem/distributions.py
+++ b/bayem/distributions.py
@@ -189,6 +189,13 @@ class Gamma:
         scale = x0 / _ppf(q=p[0], a=shape)
         return cls(shape=shape, scale=scale)
 
+    def __eq__(self, other):
+        return (
+            abs(self.scale - other.scale) < 1.0e-12
+            and abs(self.shape - other.shape) < 1.0e-12
+            and self.name == other.name
+        )
+
     @classmethod
     def FromSDQuantiles(cls, sd0, sd1, p=(0.05, 0.95)):
         """

--- a/bayem/distributions.py
+++ b/bayem/distributions.py
@@ -7,7 +7,7 @@ from tabulate import tabulate
 class MVN:
     def __init__(self, mean=[0.0], precision=[[1.0]], name="MVN", parameter_names=None):
         """
-        Creates a N-dimensional multivariate normal distribution from provided 
+        Creates a N-dimensional multivariate normal distribution from provided
         `mean` μ and `precision` L with the PDF
 
            f(x) = (2π)^(-N/2) det(L)^(1/2) exp[-1/2 (x - μ)^T L (x - μ)]
@@ -22,7 +22,7 @@ class MVN:
             name of the distribution, e.g. to indicate "prior" or "posterior"
 
         parameter_names:
-            vector of N strings that name the N parameters for convenient 
+            vector of N strings that name the N parameters for convenient
             access via `self.named_mean`
         """
         self.mean = np.atleast_1d(mean).astype(float)
@@ -39,6 +39,11 @@ class MVN:
 
         if self.parameter_names is not None:
             assert len(self.parameter_names) == len(self.mean)
+
+    @classmethod
+    def FromMeanStd(cls, mean, stds, **kwargs):
+        prec = np.diag([1 / sd ** 2 for sd in stds])
+        return cls(mean, prec, **kwargs)
 
     def __len__(self):
         return len(self.mean)
@@ -91,17 +96,25 @@ class MVN:
         s = tabulate(data_T, headers=headers)
         return s
 
+    def __eq__(self, other):
+        return (
+            np.max(np.abs(self.mean - other.mean)) < 1.0e-12
+            and np.max(np.abs(self.precision - other.precision)) < 1.0e-12
+            and self.name == other.name
+            and self.parameter_names == other.parameter_names
+        )
+
 
 class Gamma:
     def __init__(self, shape=1.0e-6, scale=1e6, name="Gamma"):
         """
-        Creates a Gamma distribution from provided `shape` k and `scale` θ 
+        Creates a Gamma distribution from provided `shape` k and `scale` θ
         with the PDF
 
             f(x) = 1 / [Γ(k) θ^k] x^(k-1) exp(-x/θ)
 
         where Γ denotes the Gamma function.
-        
+
         shape:
             shape parameter k
 
@@ -112,11 +125,11 @@ class Gamma:
             name of the distribution, e.g. to indicate "prior" or "posterior"
 
         Notes:
-            The default values aim at creating a non-informative gamma 
+            The default values aim at creating a non-informative gamma
             distribution. Ideally, we would have shape=0 and scale=inf, but
-            that raises numerical issues. Other authors [Kerman, Jouni. 
-            "Neutral noninformative and informative conjugate beta and gamma 
-            prior distributions." Electronic Journal of Statistics 5 (2011): 
+            that raises numerical issues. Other authors [Kerman, Jouni.
+            "Neutral noninformative and informative conjugate beta and gamma
+            prior distributions." Electronic Journal of Statistics 5 (2011):
             1450-1470.] propose Gamma(1/3, 0).
         """
         self.scale = scale

--- a/bayem/json_io.py
+++ b/bayem/json_io.py
@@ -4,7 +4,7 @@ from dataclasses import asdict
 import numpy as np
 
 from .distributions import MVN, Gamma
-from .vba import VBResult, VBOptions
+from .vba import VBOptions, VBResult
 
 
 class BayemEncoder(json.JSONEncoder):
@@ -48,7 +48,7 @@ class BayemEncoder(json.JSONEncoder):
         """
         if isinstance(obj, VBResult):
             return {"bayem.VBResult": obj.__dict__}
-        
+
         if isinstance(obj, VBOptions):
             return {"bayem.VBOptions": asdict(obj)}
 

--- a/bayem/vba.py
+++ b/bayem/vba.py
@@ -2,11 +2,11 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from time import perf_counter
-from tabulate import tabulate
-from typing import Union, Dict, Tuple
+from typing import Dict, Tuple, Union
 
 import numpy as np
 import scipy.special as special
+from tabulate import tabulate
 
 from .distributions import MVN, Gamma
 
@@ -142,7 +142,7 @@ class VBOptions:
     update_noise: Union[Dict, bool] = True
     index_ARD: Tuple[int] = ()
 
-    cdf_eps: float = None 
+    cdf_eps: float = None
 
     store_full_precision: bool = True
 

--- a/bayem/vba.py
+++ b/bayem/vba.py
@@ -382,7 +382,7 @@ class VBA:
             logger.info(f"Free energy of iteration {self.result.nit} is {f_new}")
 
             self.result.try_update(
-                f_new, self.m, self.L, self.c, self.s, self.x0.parameter_names
+                f_new, self.m, self.L, self.c, self.s, self.x0.parameter_names, J
             )
             if self.stop_criteria(f_new, self.result.nit):
                 break
@@ -523,6 +523,7 @@ class VBResult:
         self.f_max = -np.inf
         self.nit = 0
         self.t = None
+        self.J = None
 
     def __str__(self):
         s = "### VB Result ###\n"
@@ -543,7 +544,7 @@ class VBResult:
 
         return s
 
-    def try_update(self, f_new, mean, precision, shapes, scales, parameter_names):
+    def try_update(self, f_new, mean, precision, shapes, scales, parameter_names, J):
         self.free_energies.append(f_new)
         self.means.append(mean)
         self.sds.append(MVN(mean, precision).std_diag)
@@ -557,6 +558,7 @@ class VBResult:
             # update
             self.f_max = f_new
             self.param = MVN(mean, precision, "MVN posterior", parameter_names)
+            self.J = J
 
             for n in shapes:
                 self.noise[n] = Gamma(shape=shapes[n], scale=scales[n])

--- a/bayem/visualization.py
+++ b/bayem/visualization.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
 
-from bayem import Gamma
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D
 from matplotlib.ticker import MaxNLocator
-import matplotlib.pyplot as plt
+
+from bayem import Gamma
 
 
 def plot_pdf(
@@ -291,8 +292,6 @@ def result_trace(result, show=True, highlight=None):
         label = r"$\phi_{" + str(noise_key) + "}$"
         ax_g.errorbar(x, means, yerr=sds, label=label, capsize=5, lw=1, ls=":")
     ax_g.legend()
-
-        
 
     # annotate prior and posterior
     i_posterior = result.free_energies.index(result.f_max) + 1

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -1,20 +1,28 @@
 import numpy as np
-import bayem
 import pytest
 
+import bayem
 
-mvn = bayem.MVN( mean=np.r_[1, 2, 3], precision=np.diag([1, 2, 3]), parameter_names=["A", "B", "C"],)
+mvn = bayem.MVN(
+    mean=np.r_[1, 2, 3],
+    precision=np.diag([1, 2, 3]),
+    parameter_names=["A", "B", "C"],
+)
+
 
 def test_len():
     assert len(mvn) == 3
 
+
 def test_named_print():
     print(mvn)
+
 
 def test_named_access():
     assert mvn.index("A") == 0
     assert mvn.named_mean("A") == 1
     assert mvn.named_sd("A") == 1
+
 
 def test_dim_mismatch():
     mean2 = np.random.random(2)
@@ -27,17 +35,18 @@ def test_dim_mismatch():
     with pytest.raises(Exception):
         bayem.MVN(mean2, prec2, parameter_names=["A", "B", "C"])
 
+
 def test_dist():
     dist1D = mvn.dist(1)
     assert dist1D.mean() == 2
-    assert dist1D.std() == pytest.approx(1/2**0.5)
+    assert dist1D.std() == pytest.approx(1 / 2 ** 0.5)
 
     dist2D = mvn.dist(1, 2)
     assert dist2D.mean[0] == 2
     assert dist2D.mean[1] == 3
 
-    assert dist2D.cov[0, 0] == 1/2
-    assert dist2D.cov[1, 1] == 1/3
+    assert dist2D.cov[0, 0] == 1 / 2
+    assert dist2D.cov[1, 1] == 1 / 3
     assert dist2D.cov[0, 1] == 0
     assert dist2D.cov[1, 0] == 0
 
@@ -45,12 +54,17 @@ def test_dist():
     assert dist1D_named.mean() == 1
     assert dist1D_named.std() == 1
 
+
 def test_simple_init():
     # this mvn ...
-    mvn_ref = bayem.MVN([1,2], np.diag([1/2**2, 1/3**2]), name="test", parameter_names=["A", "B"])
+    mvn_ref = bayem.MVN(
+        [1, 2],
+        np.diag([1 / 2 ** 2, 1 / 3 ** 2]),
+        name="test",
+        parameter_names=["A", "B"],
+    )
     # ... can be directly created via
-    mvn_simple = bayem.MVN.FromMeanStd([1, 2], [2, 3], name="test", parameter_names=["A", "B"])
+    mvn_simple = bayem.MVN.FromMeanStd(
+        [1, 2], [2, 3], name="test", parameter_names=["A", "B"]
+    )
     assert mvn_ref == mvn_simple
-
-
-

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -1,56 +1,56 @@
-import unittest
 import numpy as np
 import bayem
+import pytest
 
 
-class TestMVN(unittest.TestCase):
-    def setUp(self):
-        self.mvn = bayem.MVN(
-            mean=np.r_[1, 2, 3],
-            precision=np.diag([1, 2, 3]),
-            parameter_names=["A", "B", "C"],
-        )
+mvn = bayem.MVN( mean=np.r_[1, 2, 3], precision=np.diag([1, 2, 3]), parameter_names=["A", "B", "C"],)
 
-    def test_len(self):
-        self.assertEqual(len(self.mvn), 3)
+def test_len():
+    assert len(mvn) == 3
 
-    def test_named_print(self):
-        print(self.mvn)
+def test_named_print():
+    print(mvn)
 
-    def test_named_access(self):
-        self.assertEqual(self.mvn.index("A"), 0)
-        self.assertEqual(self.mvn.named_mean("A"), 1)
-        self.assertEqual(self.mvn.named_sd("A"), 1)
+def test_named_access():
+    assert mvn.index("A") == 0
+    pytest.approx(mvn.named_mean("A"), 1)
+    pytest.approx(mvn.named_sd("A"), 1)
 
-    def test_dim_mismatch(self):
-        mean2 = np.random.random(2)
-        prec2 = np.random.random((2, 2))
-        prec3 = np.random.random((3, 3))
-        with self.assertRaises(Exception):
-            bayem.MVN(mean2, prec3)
+def test_dim_mismatch():
+    mean2 = np.random.random(2)
+    prec2 = np.random.random((2, 2))
+    prec3 = np.random.random((3, 3))
+    with pytest.raises(Exception):
+        bayem.MVN(mean2, prec3)
 
-        bayem.MVN(mean2, prec2)  # no exception!
-        with self.assertRaises(Exception):
-            bayem.MVN(mean2, prec2, parameter_names=["A", "B", "C"])
+    bayem.MVN(mean2, prec2)  # no exception!
+    with pytest.raises(Exception):
+        bayem.MVN(mean2, prec2, parameter_names=["A", "B", "C"])
 
-    def test_dist(self):
-        dist1D = self.mvn.dist(1)
-        self.assertAlmostEqual(dist1D.mean(), 2)
-        self.assertAlmostEqual(dist1D.std(), 1/2**0.5)
+def test_dist():
+    dist1D = mvn.dist(1)
+    pytest.approx(dist1D.mean(), 2)
+    pytest.approx(dist1D.std(), 1/2**0.5)
 
-        dist2D = self.mvn.dist(1, 2)
-        self.assertAlmostEqual(dist2D.mean[0], 2)
-        self.assertAlmostEqual(dist2D.mean[1], 3)
+    dist2D = mvn.dist(1, 2)
+    pytest.approx(dist2D.mean[0], 2)
+    pytest.approx(dist2D.mean[1], 3)
 
-        self.assertAlmostEqual(dist2D.cov[0, 0], 1/2)
-        self.assertAlmostEqual(dist2D.cov[1, 1], 1/3)
-        self.assertAlmostEqual(dist2D.cov[0, 1], 0)
-        self.assertAlmostEqual(dist2D.cov[1, 0], 0)
+    pytest.approx(dist2D.cov[0, 0], 1/2)
+    pytest.approx(dist2D.cov[1, 1], 1/3)
+    pytest.approx(dist2D.cov[0, 1], 0)
+    pytest.approx(dist2D.cov[1, 0], 0)
 
-        dist1D_named = self.mvn.dist("A")
-        self.assertAlmostEqual(dist1D_named.mean(), 1)
-        self.assertAlmostEqual(dist1D_named.std(), 1)
+    dist1D_named = mvn.dist("A")
+    pytest.approx(dist1D_named.mean(), 1)
+    pytest.approx(dist1D_named.std(), 1)
+
+def test_simple_init():
+    # this mvn ...
+    mvn_ref = bayem.MVN([1,2], np.diag([1/2**2, 1/3**2]), name="test", parameter_names=["A", "B"])
+    # ... can be directly created via
+    mvn_simple = bayem.MVN.FromMeanStd([1, 2], [2, 3], name="test", parameter_names=["A", "B"])
+    assert mvn_ref == mvn_simple
 
 
-if __name__ == "__main__":
-    unittest.main()
+

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -13,8 +13,8 @@ def test_named_print():
 
 def test_named_access():
     assert mvn.index("A") == 0
-    pytest.approx(mvn.named_mean("A"), 1)
-    pytest.approx(mvn.named_sd("A"), 1)
+    assert mvn.named_mean("A") == 1
+    assert mvn.named_sd("A") == 1
 
 def test_dim_mismatch():
     mean2 = np.random.random(2)
@@ -29,21 +29,21 @@ def test_dim_mismatch():
 
 def test_dist():
     dist1D = mvn.dist(1)
-    pytest.approx(dist1D.mean(), 2)
-    pytest.approx(dist1D.std(), 1/2**0.5)
+    assert dist1D.mean() == 2
+    assert dist1D.std() == pytest.approx(1/2**0.5)
 
     dist2D = mvn.dist(1, 2)
-    pytest.approx(dist2D.mean[0], 2)
-    pytest.approx(dist2D.mean[1], 3)
+    assert dist2D.mean[0] == 2
+    assert dist2D.mean[1] == 3
 
-    pytest.approx(dist2D.cov[0, 0], 1/2)
-    pytest.approx(dist2D.cov[1, 1], 1/3)
-    pytest.approx(dist2D.cov[0, 1], 0)
-    pytest.approx(dist2D.cov[1, 0], 0)
+    assert dist2D.cov[0, 0] == 1/2
+    assert dist2D.cov[1, 1] == 1/3
+    assert dist2D.cov[0, 1] == 0
+    assert dist2D.cov[1, 0] == 0
 
     dist1D_named = mvn.dist("A")
-    pytest.approx(dist1D_named.mean(), 1)
-    pytest.approx(dist1D_named.std(), 1)
+    assert dist1D_named.mean() == 1
+    assert dist1D_named.std() == 1
 
 def test_simple_init():
     # this mvn ...

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -10,9 +10,9 @@ def test_sd():
     scale, shape = 42, 6174
     gamma = bayem.Gamma(shape=shape, scale=scale)
 
-    pytest.approx(gamma.mean, shape * scale)
+    assert gamma.mean == pytest.approx(shape * scale)
     variance = shape * scale ** 2
-    pytest.approx(gamma.std, variance ** 0.5)
+    assert gamma.std == pytest.approx(variance ** 0.5)
 
 
 @settings(derandomize=True, max_examples=200)
@@ -33,8 +33,8 @@ def test_from_quantiles(x0_x1):
     gamma = bayem.Gamma.FromQuantiles(x0, x1, q)
     d = gamma.dist()
 
-    pytest.approx(d.cdf(x0), q[0])
-    pytest.approx(d.cdf(x1), q[1])
+    assert d.cdf(x0) == pytest.approx(q[0])
+    assert d.cdf(x1) == pytest.approx(q[1])
 
 def test_from_mean_and_sd():
     gamma_ref = bayem.Gamma(6174, 42)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,53 +1,50 @@
-import unittest
 import bayem
 from hypothesis import given, settings
 import hypothesis.strategies as st
+import pytest
+
+def test_print():
+    print(bayem.Gamma(42, 2))
+    
+def test_sd():
+    scale, shape = 42, 6174
+    gamma = bayem.Gamma(shape=shape, scale=scale)
+
+    pytest.approx(gamma.mean, shape * scale)
+    variance = shape * scale ** 2
+    pytest.approx(gamma.std, variance ** 0.5)
 
 
-class TestGamma(unittest.TestCase):
-    def test_print(self):
-        print(bayem.Gamma(42, 2))
-
-    def test_sd(self):
-        scale, shape = 42, 6174
-        gamma = bayem.Gamma(shape=shape, scale=scale)
-        self.assertAlmostEqual(gamma.mean, shape * scale)
-        variance = shape * scale ** 2
-        self.assertAlmostEqual(gamma.std, variance ** 0.5)
-
-    def test_from_mean_and_sd(self):
-        gamma = bayem.Gamma.FromMeanStd(6174, 42)
-        self.assertAlmostEqual(gamma.mean, 6174)
-        self.assertAlmostEqual(gamma.std, 42)
-
-    @settings(derandomize=True, max_examples=200)
-    @given(
-        st.tuples(
-            st.floats(min_value=1.0e-4, max_value=1e4),
-            st.floats(min_value=1.0e-4, max_value=1e4),
-        )
+@settings(derandomize=True, max_examples=200)
+@given(
+    st.tuples(
+        st.floats(min_value=1.0e-4, max_value=1e4),
+        st.floats(min_value=1.0e-4, max_value=1e4),
     )
-    def test_from_quantiles(self, x0_x1):
-        x0, x1 = x0_x1
-        if x0 == x1:
-            return
-        if x0 > x1:
-            x1, x0 = x0, x1
+)
+def test_from_quantiles(x0_x1):
+    x0, x1 = x0_x1
+    if x0 == x1:
+        return
+    if x0 > x1:
+        x1, x0 = x0, x1
 
-        q = (0.15, 0.95)
-        gamma = bayem.Gamma.FromQuantiles(x0, x1, q)
-        d = gamma.dist()
+    q = (0.15, 0.95)
+    gamma = bayem.Gamma.FromQuantiles(x0, x1, q)
+    d = gamma.dist()
 
-        self.assertAlmostEqual(d.cdf(x0), q[0])
-        self.assertAlmostEqual(d.cdf(x1), q[1])
+    pytest.approx(d.cdf(x0), q[0])
+    pytest.approx(d.cdf(x1), q[1])
 
-    def test_from_sd_quantiles(self):
-        gamma = bayem.Gamma.FromSDQuantiles(4, 6)
-        sd_mean = 1 / gamma.mean ** 0.5
+def test_from_mean_and_sd():
+    gamma_ref = bayem.Gamma(6174, 42)
 
-        self.assertGreater(sd_mean, 4)
-        self.assertLess(sd_mean, 6)
+    gamma = bayem.Gamma.FromMeanStd(gamma_ref.mean, gamma_ref.std)
+    assert gamma == gamma_ref
 
+def test_from_sd_quantiles():
+    gamma = bayem.Gamma.FromSDQuantiles(4, 6)
+    sd_mean = 1 / gamma.mean ** 0.5
 
-if __name__ == "__main__":
-    unittest.main()
+    assert 4 < sd_mean < 6
+

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -14,8 +14,7 @@ def test_sd():
     gamma = bayem.Gamma(shape=shape, scale=scale)
 
     assert gamma.mean == pytest.approx(shape * scale)
-    variance = shape * scale ** 2
-    assert gamma.std == pytest.approx(variance ** 0.5)
+    assert gamma.std ** 2 == pytest.approx(shape * scale ** 2)  # variance
 
 
 @settings(derandomize=True, max_examples=200)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,11 +1,14 @@
-import bayem
-from hypothesis import given, settings
 import hypothesis.strategies as st
 import pytest
+from hypothesis import given, settings
+
+import bayem
+
 
 def test_print():
     print(bayem.Gamma(42, 2))
-    
+
+
 def test_sd():
     scale, shape = 42, 6174
     gamma = bayem.Gamma(shape=shape, scale=scale)
@@ -36,15 +39,16 @@ def test_from_quantiles(x0_x1):
     assert d.cdf(x0) == pytest.approx(q[0])
     assert d.cdf(x1) == pytest.approx(q[1])
 
+
 def test_from_mean_and_sd():
     gamma_ref = bayem.Gamma(6174, 42)
 
     gamma = bayem.Gamma.FromMeanStd(gamma_ref.mean, gamma_ref.std)
     assert gamma == gamma_ref
 
+
 def test_from_sd_quantiles():
     gamma = bayem.Gamma.FromSDQuantiles(4, 6)
     sd_mean = 1 / gamma.mean ** 0.5
 
     assert 4 < sd_mean < 6
-

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,7 +1,9 @@
-import numpy as np
-import bayem
-from tempfile import TemporaryDirectory
 from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+
+import bayem
 
 
 def test_result_io():

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -18,6 +18,20 @@ def test_linear_model():
     assert 0 < result["noise_group"]["B"] < 1.0e-8
 
 
+def test_custom_sd_range():
+    def f(theta):
+        return {"noise_group": x / theta[0]}
+
+    # The default setting will test a parameter range
+    # -2, -1, 0, 1, 2, 3, 4
+    # where theta == 0 causes a division by zero in the model.
+    with pytest.warns(RuntimeWarning):
+        bayem.linearity_analysis(f, bayem.MVN(1, 1))
+
+    # We can avoid that by manually adjusting the checked range.
+    bayem.linearity_analysis(f, bayem.MVN(1, 1), sd_range=np.linspace(-0.9, 0.9, 5))
+
+
 def test_nonlinear_model():
     def f(theta):
         return x / theta[0] + theta[1]

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -1,6 +1,7 @@
 import numpy as np
-import bayem
 import pytest
+
+import bayem
 
 N_sensors = 20
 x = np.linspace(0, 1, N_sensors)
@@ -8,7 +9,7 @@ x = np.linspace(0, 1, N_sensors)
 
 def test_linear_model():
     def f(theta):
-        return {"noise_group" : x * theta[0] + theta[1]}
+        return {"noise_group": x * theta[0] + theta[1]}
 
     mvn = bayem.MVN.FromMeanStd([1, 1], [0.5, 0.5], parameter_names=["A", "B"])
 
@@ -26,10 +27,10 @@ def test_nonlinear_model():
 
     result0 = bayem.linearity_analysis(f, mvn0)
     assert result0[0] > 0.1
-    assert 0 < result0[1] < 1.0e-8 # the model is still linear in theta[1]
+    assert 0 < result0[1] < 1.0e-8  # the model is still linear in theta[1]
 
     # MVN with its mean in region of _low_ nonlinearity
     mvn1 = bayem.MVN.FromMeanStd([10, 1], [0.2, 0.2], parameter_names=[0, 1])
     result1 = bayem.linearity_analysis(f, mvn1)
     assert 0 < result1[0] < 0.001  # lower "measure" of nonlinearity
-    assert 0 < result1[1] < 1.0e-8 # the model is still linear in theta[1]
+    assert 0 < result1[1] < 1.0e-8  # the model is still linear in theta[1]

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -34,3 +34,14 @@ def test_nonlinear_model():
     result1 = bayem.linearity_analysis(f, mvn1)
     assert 0 < result1[0] < 0.001  # lower "measure" of nonlinearity
     assert 0 < result1[1] < 1.0e-8  # the model is still linear in theta[1]
+
+
+def test_zero_model():
+    def f(theta):
+        """
+        Could triggers division by zero in norm calculation
+        """
+        return np.zeros(42)
+
+    a = bayem.linearity_analysis(f, bayem.MVN(4, 2, parameter_names=["A"]))
+    assert np.isnan(a["A"])

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -13,9 +13,16 @@ def test_linear_model():
 
     mvn = bayem.MVN.FromMeanStd([1, 1], [0.5, 0.5], parameter_names=["A", "B"])
 
-    result = bayem.linearity_analysis(f, mvn)
+    sd_range = range(-3, 4)
+    result, values = bayem.linearity_analysis(f, mvn, sd_range=sd_range, ret_values=True)
     assert 0 < result["noise_group"]["A"] < 1.0e-8
     assert 0 < result["noise_group"]["B"] < 1.0e-8
+
+    # test access to raw values
+    test_me_true, test_me_lin = values["noise_group"]["A"]
+    assert len(test_me_true) == len(sd_range)
+    for me in test_me_true:
+        assert len(me) == N_sensors
 
 
 def test_custom_sd_range():

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -8,13 +8,13 @@ x = np.linspace(0, 1, N_sensors)
 
 def test_linear_model():
     def f(theta):
-        return x * theta[0] + theta[1]
+        return {"noise_group" : x * theta[0] + theta[1]}
 
-    mvn = bayem.MVN.FromMeanStd([1, 1], [0.5, 0.5], parameter_names=[0, 1])
+    mvn = bayem.MVN.FromMeanStd([1, 1], [0.5, 0.5], parameter_names=["A", "B"])
 
     result = bayem.linearity_analysis(f, mvn)
-    assert 0 < result[0] < 1.0e-8
-    assert 0 < result[1] < 1.0e-8
+    assert 0 < result["noise_group"]["A"] < 1.0e-8
+    assert 0 < result["noise_group"]["B"] < 1.0e-8
 
 
 def test_nonlinear_model():
@@ -24,7 +24,7 @@ def test_nonlinear_model():
     # MVN with its mean in region of high nonlinearity
     mvn0 = bayem.MVN.FromMeanStd([1, 1], [0.3, 0.3], parameter_names=[0, 1])
 
-    result0 = bayem.linearity_analysis(f, mvn0, show=True)
+    result0 = bayem.linearity_analysis(f, mvn0)
     assert result0[0] > 0.1
     assert 0 < result0[1] < 1.0e-8 # the model is still linear in theta[1]
 

--- a/tests/test_linearity.py
+++ b/tests/test_linearity.py
@@ -1,0 +1,35 @@
+import numpy as np
+import bayem
+import pytest
+
+N_sensors = 20
+x = np.linspace(0, 1, N_sensors)
+
+
+def test_linear_model():
+    def f(theta):
+        return x * theta[0] + theta[1]
+
+    mvn = bayem.MVN.FromMeanStd([1, 1], [0.5, 0.5], parameter_names=[0, 1])
+
+    result = bayem.linearity_analysis(f, mvn)
+    assert 0 < result[0] < 1.0e-8
+    assert 0 < result[1] < 1.0e-8
+
+
+def test_nonlinear_model():
+    def f(theta):
+        return x / theta[0] + theta[1]
+
+    # MVN with its mean in region of high nonlinearity
+    mvn0 = bayem.MVN.FromMeanStd([1, 1], [0.3, 0.3], parameter_names=[0, 1])
+
+    result0 = bayem.linearity_analysis(f, mvn0, show=True)
+    assert result0[0] > 0.1
+    assert 0 < result0[1] < 1.0e-8 # the model is still linear in theta[1]
+
+    # MVN with its mean in region of _low_ nonlinearity
+    mvn1 = bayem.MVN.FromMeanStd([10, 1], [0.2, 0.2], parameter_names=[0, 1])
+    result1 = bayem.linearity_analysis(f, mvn1)
+    assert 0 < result1[0] < 0.001  # lower "measure" of nonlinearity
+    assert 0 < result1[1] < 1.0e-8 # the model is still linear in theta[1]

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import bayem
 
 

--- a/tests/test_vb_ARD.py
+++ b/tests/test_vb_ARD.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
-import bayem
 from test_vb import ModelError
+
+import bayem
 
 """
 Test having an ARD parameter (see Chappell paper for more info)
@@ -72,6 +73,7 @@ info = bayem.vba(
     maxtrials=50,
     update_noise=True,
 )
+
 
 @pytest.mark.skip(reason="There is something going wrong in this test design.")
 def test_checks():

--- a/tests/test_vb_analytical.py
+++ b/tests/test_vb_analytical.py
@@ -1,5 +1,7 @@
-import numpy as np
 import unittest
+
+import numpy as np
+
 import bayem
 
 """

--- a/tests/test_vb_exceptions.py
+++ b/tests/test_vb_exceptions.py
@@ -1,5 +1,6 @@
-import bayem
 import pytest
+
+import bayem
 
 x0 = bayem.MVN()
 

--- a/tests/test_vb_minimal.py
+++ b/tests/test_vb_minimal.py
@@ -1,6 +1,7 @@
-import bayem
 import numpy as np
 import pytest
+
+import bayem
 
 np.random.seed(6174)
 x = np.linspace(0, 1, 1000)
@@ -29,7 +30,9 @@ def test_results():
     post_noise_std = 1.0 / post_noise_precision ** 0.5
     assert post_noise_std == pytest.approx(sd, rel=0.01)
 
-    assert info.nit < 4 # For such linear regression we do expect to have very few iterations.
+    assert (
+        info.nit < 4
+    )  # For such linear regression we do expect to have very few iterations.
     assert info.t < 0.1
 
     info.summary(True)

--- a/tests/test_vb_noises.py
+++ b/tests/test_vb_noises.py
@@ -1,5 +1,7 @@
-import numpy as np
 import unittest
+
+import numpy as np
+
 import bayem
 
 PRM_A, PRM_B = 7.0, 10.0  # slope and offset to identify
@@ -98,9 +100,9 @@ class TestTwoNoises(unittest.TestCase):
         wrong_noise = bayem.Gamma((1, 1), (2, 2))
         with self.assertRaises(Exception):
             bayem.vba(me, bayem.MVN(7, 12), wrong_noise)
-    
+
     def test_several_noises_mixed(self):
-        """ Test if an identifiable noise group is updated and another that is prescribed is not."""
+        """Test if an identifiable noise group is updated and another that is prescribed is not."""
         noise_prior = {}
         update_noise = {}
         noise_prior["group0"] = bayem.Gamma.FromSDQuantiles(
@@ -112,12 +114,12 @@ class TestTwoNoises(unittest.TestCase):
         )
         update_noise["group1"] = True
         info = self.run_test(noise_prior, delta=0.05, update_noise=update_noise)
-        
-        assert (info.noise['group0'].scale == noise_prior['group0'].scale)
-        assert (info.noise['group0'].shape == noise_prior['group0'].shape)
-        
-        assert (info.noise['group1'].scale != noise_prior['group1'].scale)
-        assert (info.noise['group1'].shape != noise_prior['group1'].shape)
+
+        assert info.noise["group0"].scale == noise_prior["group0"].scale
+        assert info.noise["group0"].shape == noise_prior["group0"].shape
+
+        assert info.noise["group1"].scale != noise_prior["group1"].scale
+        assert info.noise["group1"].shape != noise_prior["group1"].shape
 
 
 if __name__ == "__main__":

--- a/tests/test_vb_stop.py
+++ b/tests/test_vb_stop.py
@@ -1,7 +1,9 @@
-from scipy import stats
-import numpy as np
-import unittest
 import logging
+import unittest
+
+import numpy as np
+from scipy import stats
+
 from bayem import VBA, VBOptions
 
 logging.getLogger("matplotlib.font_manager").disabled = True

--- a/tests/test_vb_visu.py
+++ b/tests/test_vb_visu.py
@@ -1,16 +1,18 @@
 import tempfile
 from pathlib import Path
 
-import bayem
-import bayem.visualization as visu
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from imageio import imread
 
+import bayem
+import bayem.visualization as visu
+
+
 def compare_plt(reference_filename, generate_ref_img):
     ref_img_name = Path(__file__).absolute().parent / reference_filename
-    if generate_ref_img: 
+    if generate_ref_img:
         plt.savefig(ref_img_name, dpi=300)
         return
 
@@ -23,12 +25,15 @@ def compare_plt(reference_filename, generate_ref_img):
 
         assert np.linalg.norm(test_img - ref_img) == pytest.approx(0)
 
+
 np.random.seed(6174)
 t = np.linspace(1, 2, 10)
 noise = np.random.normal(0, 0.42, len(t))
 
+
 def f(x):
-    return t * x[0]**2 - t * 9 + noise
+    return t * x[0] ** 2 - t * 9 + noise
+
 
 info = bayem.vba(f, x0=bayem.MVN([2], [0.5]), noise0=bayem.Gamma(1, 2))
 
@@ -36,6 +41,7 @@ info = bayem.vba(f, x0=bayem.MVN([2], [0.5]), noise0=bayem.Gamma(1, 2))
 def test_pair_plot(generate_ref_img=False):
     visu.pair_plot(info, show=False)
     compare_plt("ref_pair_plot.png", generate_ref_img=generate_ref_img)
+
 
 def test_trace_plot(generate_ref_img=False):
     visu.result_trace(info, show=False)

--- a/tests/test_vba_api.py
+++ b/tests/test_vba_api.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import bayem
 
 np.random.seed(6174)


### PR DESCRIPTION
My rough understanding is, that when the linearity assumption
> k(theta) ~ k(m) + J(m) (theta - m)

does not hold, the priors and posteriors of the model parameters are no longer conjugate. And the more _nonlinear_ the model is, the worse. 

This PR provides the basic frame for measuring the nonlinearity in `bayem.linearity_analysis(model, posterior,...)`. Currently, the actual model (error) and its linearization are evaluated a number of (posterior) standard deviations around the posterior mean, by default 7 times at µ + sd * (-3, -2, -1, 0, 1, 2, 3). This results in a matrix M of shape (N_model_error x 7) and the relative error
>  || M_true - M_lin || / || M_lin ||

is used as a measure. The exact definition of this norm is user provided, but np.linalg.norm seems to work. If the model is a good linear fit (around the posterior mean), this value will go to zero.

The output is a nested `dict{noise_group: {parameter: relative error}}`. And the argument `show=True` provides a debug visualization.