### PR TITLE
Bugfixes on Bivariate quantiles

### DIFF
--- a/bayem/visualization.py
+++ b/bayem/visualization.py
@@ -49,6 +49,16 @@ def plot_pdf(
         plt.show()
 
 
+def _get_levels(pdf, quantiles):
+    level_range = np.linspace(np.min(pdf), np.max(pdf), 15)[:-1]
+
+    sums = [np.sum(pdf[pdf > level]) for level in level_range]
+    prob_density = np.asarray(sums) / np.sum(pdf)
+
+    interpolator = interp1d(prob_density, level_range, kind="quadratic")
+    return interpolator(quantiles)
+
+
 def visualize_vb_marginal_matrix(
     mvn,
     gammas=None,
@@ -124,19 +134,10 @@ def visualize_vb_marginal_matrix(
                 pdf_j = dists_1d[j].pdf(xs[j]).reshape(-1, 1)
                 pdf = pdf_j @ pdf_i.T
 
-                def get_levels(quantiles):
-                    level_range = np.linspace(np.min(pdf), np.max(pdf), 15)[:-1]
-
-                    sums = [np.sum(pdf[pdf > level]) for level in level_range]
-                    prob_density = np.asarray(sums) / np.sum(pdf)
-
-                    interpolator = interp1d(prob_density, level_range, kind="quadratic")
-                    return interpolator(quantiles)
-
-                levels = get_levels(np.sort(contour_quantiles)[::-1])
-                axes[i, j].contour(
-                    xj, xi, pdf, levels=levels, colors=[color], linewidths=lw
-                )
+            levels = _get_levels(pdf, np.sort(contour_quantiles)[::-1])
+            axes[i, j].contour(
+                xj, xi, pdf, levels=levels, colors=[color], linewidths=lw
+            )
 
     if median:
         for i in range(N):

--- a/tests/test_vb_visu.py
+++ b/tests/test_vb_visu.py
@@ -39,7 +39,7 @@ info = bayem.vba(f, x0=bayem.MVN([2], [0.5]), noise0=bayem.Gamma(1, 2))
 
 
 def test_pair_plot(generate_ref_img=False):
-    # use crafted posterior close to the prior for visually more interesting 
+    # use crafted posterior close to the prior for visually more interesting
     # plot
     info.param = bayem.MVN(1.5, 0.3)
     visu.pair_plot(info, show=False)
@@ -51,7 +51,26 @@ def test_trace_plot(generate_ref_img=False):
     compare_plt("ref_trace_plot.png", generate_ref_img=generate_ref_img)
 
 
+def test_quantile_levels():
+    mvn = bayem.MVN([2, 3], [[0.5, 0.2], [0.2, 0.5]])
+    res = 201
+    x0 = np.linspace(mvn.dist(0).ppf(0.001), mvn.dist(0).ppf(0.999), res)
+    x1 = np.linspace(mvn.dist(1).ppf(0.001), mvn.dist(1).ppf(0.999), res)
+    xi, xj = np.meshgrid(x0, x1)
+
+    x = np.vstack([xi.flatten(), xj.flatten()]).T
+    pdf = mvn.dist(0, 1).pdf(x).reshape(res, res)
+
+    alpha = 0.9
+    level = visu._get_levels(pdf, alpha)
+
+    level_ref = alpha * (1 / np.sqrt((2 * np.pi) ** 2) / np.linalg.det(mvn.cov)) * 0.9
+
+    assert level_ref == pytest.approx(level)
+
+
 if __name__ == "__main__":
     generate = True
+    test_quantile_levels()
     test_pair_plot(generate_ref_img=generate)
     test_trace_plot(generate_ref_img=generate)


### PR DESCRIPTION
The quantile levels were only calculated for a mix of gaussian/gamma, not for gaussian/gaussian.

Also this provides a test that compares the numerically obtained level to the formula in #94. Does not match though. On first glance, I couldn't find the formula in the link provided.

I recommend at least merging the first commit of this PR.