### PR TITLE
Handle 'type' objects in json serialization

### DIFF
--- a/bayem/json_io.py
+++ b/bayem/json_io.py
@@ -60,6 +60,9 @@ class BayemEncoder(json.JSONEncoder):
 
         if isinstance(obj, np.ndarray):
             return {"np.array": obj.tolist()}
+        
+        if isinstance(obj, type):
+            return {"type_object": obj.__name__}
 
         # `obj` is not one of our types? Fall back to superclass implementation.
         return json.JSONEncoder.default(self, obj)
@@ -104,6 +107,10 @@ def bayem_hook(dct):
 
     if "np.array" in dct:
         return np.array(dct["np.array"])
+    
+    if "type_object" in dct:
+        from pydoc import locate
+        return locate(dct["type_object"])
 
     # Type not recognized, just return the dict.
     return dct


### PR DESCRIPTION
There is an option of allowed_exceptions in VB, which allows us to ignore a given list of exceptions in all of VB iterations. This item includes 'type' objects (e.g. Exception), which was not handled in json- serialization and deserialization. So, this has now been added.